### PR TITLE
Build refinements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
-CFLAGS = -Iinclude/imgtotxt -Iinclude/miniaudio -I/usr/include/chafa -I/usr/lib/chafa/include -I/usr/lib/x86_64-linux-gnu/glib-2.0/include/ -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -O1 `pkg-config --cflags glib-2.0 chafa`
-LIBS =  -lpthread -lavformat -lavutil -L/usr/lib -lfftw3_omp -lfftw3 -lfftw3f_omp -lfftw3f -lrt -pthread -lcurl -lm -lfreeimage -lchafa `pkg-config --libs glib-2.0 chafa`
+CFLAGS = -Iinclude/imgtotxt -Iinclude/miniaudio -O1 `pkg-config --cflags chafa libavformat fftw3f`
+LIBS =  -lpthread -lrt -pthread -lcurl -lm -lfreeimage `pkg-config --libs chafa libavformat fftw3f`
 
 OBJDIR = src/obj
 

--- a/Makefile
+++ b/Makefile
@@ -9,16 +9,16 @@ OBJS = $(SRCS:src/%.c=$(OBJDIR)/%.o)
 
 all: cue
 
-$(OBJDIR)/%.o: src/%.c | $(OBJDIR)
+$(OBJDIR)/%.o: src/%.c Makefile | $(OBJDIR)
 	$(CC) $(CFLAGS) -c -o $@ $<
 
-$(OBJDIR)/write_ascii.o: include/imgtotxt/write_ascii.c | $(OBJDIR)
+$(OBJDIR)/write_ascii.o: include/imgtotxt/write_ascii.c Makefile | $(OBJDIR)
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 $(OBJDIR):
 	mkdir -p $(OBJDIR)
 
-cue: $(OBJDIR)/write_ascii.o $(OBJS)
+cue: $(OBJDIR)/write_ascii.o $(OBJS) Makefile
 	$(CC) -o cue $(OBJDIR)/write_ascii.o $(OBJS) $(LIBS)
 
 .PHONY: install


### PR DESCRIPTION
This will get more build flags from `pkg-config`, cutting down on redundancies, and rebuild whenever `Makefile` changes.