### PR TITLE
Swapped ← and →

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ cue . (loads the main cue playlist, see 'Other Functions')
 #### Other Functions:
 
 * Use <kbd>↑</kbd>, <kbd>↓</kbd> keys to raise or lower volume. 
-* Use <kbd>←</kbd>, <kbd>→</kbd> keys to play the previous track in the playlist. 
+* Use <kbd>←</kbd>, <kbd>→</kbd> keys to play the previous or next track in the playlist. 
 * <kbd>Space</kbd> to toggle pause.
 * <kbd>F1</kbd> to show/hide the playlist and information about cue.
 * <kbd>F2</kbd> to show/hide key bindings.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ cue . (loads the main cue playlist, see 'Other Functions')
 #### Other Functions:
 
 * Use <kbd>↑</kbd>, <kbd>↓</kbd> keys to raise or lower volume. 
-* Use <kbd>→</kbd>, <kbd>←</kbd> keys to play the next or previous track in the playlist. 
+* Use <kbd>←</kbd>, <kbd>→</kbd> keys to play the previous track in the playlist. 
 * <kbd>Space</kbd> to toggle pause.
 * <kbd>F1</kbd> to show/hide the playlist and information about cue.
 * <kbd>F2</kbd> to show/hide key bindings.

--- a/src/player.c
+++ b/src/player.c
@@ -362,7 +362,7 @@ int showKeyBindings()
     numPrintedRows += printAbout();
     setTextColorRGB2(color.r, color.g, color.b);        
     printf(" Use ↑, ↓ keys to raise or lower volume.\n");
-    printf(" Use →, ← keys to play the next or previous track.\n");
+    printf(" Use ←, → keys to play the previous or track track.\n");
     printf(" Space to toggle pause.\n");
     printf(" F1 to show/hide the playlist.\n");
     printf(" F2 to show/hide key bindings.\n");    

--- a/src/player.c
+++ b/src/player.c
@@ -362,7 +362,7 @@ int showKeyBindings()
     numPrintedRows += printAbout();
     setTextColorRGB2(color.r, color.g, color.b);        
     printf(" Use ↑, ↓ keys to raise or lower volume.\n");
-    printf(" Use ←, → keys to play the previous or track track.\n");
+    printf(" Use ←, → keys to play the previous or next track.\n");
     printf(" Space to toggle pause.\n");
     printf(" F1 to show/hide the playlist.\n");
     printf(" F2 to show/hide key bindings.\n");    


### PR DESCRIPTION
Felt it would be better since the left arrow key is obviously on the left side of the right arrow key on the keyboard, and it was the opposite in the readme and keybind list.